### PR TITLE
Refactor progress engine: share one Manager, drop dead code

### DIFF
--- a/parallel_pandas/core/parallel_dataframe.py
+++ b/parallel_pandas/core/parallel_dataframe.py
@@ -5,7 +5,6 @@ from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 from multiprocessing import cpu_count
 
 from functools import partial
-from multiprocessing import Manager
 import numpy as np
 import pandas as pd
 from pandas._libs import lib
@@ -23,6 +22,7 @@ import dill
 from ._numba import _do_parallel_corr
 from .progress_imap import progress_imap
 from .progress_imap import progress_udf_wrapper
+from .progress_imap import get_workers_queue
 from .tools import (
     get_pandas_version,
     parallel_rank,
@@ -45,7 +45,7 @@ def _do_apply(data, dill_func, workers_queue, axis, raw, result_type, args, kwar
 def parallelize_apply(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
     @doc(DOC, func='apply')
     def p_apply(data, func, executor='processes', axis=0, raw=False, result_type=None, args=(), **kwargs):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, axis, split_size)
         dill_func = dill.dumps(func)
@@ -74,7 +74,7 @@ def _do_chunk_apply(data, dill_func, workers_queue, args, kwargs):
 def parallelize_chunk_apply(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
     def chunk_apply(data, func, executor='processes', axis=0, split_by_col=None,
                     concat_result=True, args=(), **kwargs):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         if split_by_col:
             t = data[split_by_col].unique()
@@ -254,7 +254,7 @@ def _do_aggregate(data, func, workers_queue, dilled_func, axis, args, kwargs):
 def parallelize_aggregate(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
     @doc(DOC, func='aggregate')
     def p_aggregate(data, func, executor='threads', axis=0, args=(), **kwargs):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, axis, split_size)
         dilled_func = False
@@ -285,7 +285,7 @@ def parallelize_replace(n_cpu=None, disable_pr_bar=False, show_vmem=False, split
     @doc(DOC, func='replace')
     def p_replace(data, to_replace=None, value=lib.no_default, limit=None,
                   regex: bool = False, method: str | lib.NoDefault = lib.no_default):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, 1, split_size)
         result = progress_imap(partial(_do_replace, to_replace=to_replace, value=value, limit=limit, regex=regex,
@@ -307,7 +307,7 @@ def do_applymap(df, workers_queue, dill_func, na_action, kwargs):
 def parallelize_applymap(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
     @doc(DOC, func='applymap')
     def p_applymap(data, func, na_action=None, **kwargs):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, 1, split_size)
         dill_func = dill.dumps(func)
@@ -329,7 +329,7 @@ def do_map(df, workers_queue, dill_func, na_action, kwargs):
 def parallelize_map(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
     @doc(DOC, func='map')
     def p_map(data, func, na_action=None, **kwargs):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, 1, split_size)
         dill_func = dill.dumps(func)
@@ -363,7 +363,7 @@ def parallelize_describe(n_cpu=None, disable_pr_bar=False, show_vmem=False, spli
         if MAJOR_PANDAS_VERSION > 1:
             if datetime_is_numeric:
                 warnings.warn('datetime_is_numeric is deprecated since pandas 2.0.0')
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, 0, split_size)
         result = progress_imap(
@@ -390,7 +390,7 @@ def parallelize_pct_change(n_cpu=None, disable_pr_bar=False, show_vmem=False, sp
                      freq=None,
                      **kwargs, ):
         axis = kwargs.get('axis', 0)
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, axis, split_size)
         result = progress_imap(
@@ -422,7 +422,7 @@ def do_mad(df, workers_queue, axis, skipna, level):
 def parallelize_mad(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
     @doc(DOC, func='mad')
     def p_mad(data, axis=0, skipna=True, level=None):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, axis, split_size)
         total = min(split_size, data.shape[1 - axis])
@@ -445,7 +445,7 @@ def do_idxmax(df, workers_queue, axis, skipna):
 def parallelize_idxmax(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
     @doc(DOC, func='idxmax')
     def p_idxmax(data, axis=0, skipna=True):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, axis, split_size)
         total = min(split_size, data.shape[1 - axis])
@@ -468,7 +468,7 @@ def do_idxmin(df, workers_queue, axis, skipna):
 def parallelize_idxmin(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
     @doc(DOC, func='idxmin')
     def p_idxmin(data, axis=0, skipna=True):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, axis, split_size)
         total = min(split_size, data.shape[1 - axis])
@@ -494,7 +494,7 @@ def parallelize_rank(n_cpu=None, disable_pr_bar=False, split_factor=1,
     @doc(DOC, func='rank')
     def p_rank(data, axis=0, method: str = "average", numeric_only=lib.no_default, na_option="keep", ascending=True,
                pct=False):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, axis, split_size)
         total = min(split_size, data.shape[1 - axis])
@@ -519,7 +519,7 @@ def parallelize_quantile(n_cpu=None, disable_pr_bar=False, split_factor=1,
                          show_vmem=False):
     @doc(DOC, func='quantile')
     def p_quantile(data, q=0.5, axis=0, numeric_only: bool = True, interpolation: str = "linear"):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, axis, split_size)
         total = min(split_size, data.shape[1 - axis])
@@ -546,7 +546,7 @@ def parallelize_mode(n_cpu=None, disable_pr_bar=False, split_factor=1,
                      show_vmem=False):
     @doc(DOC, func='mode')
     def p_mode(data, executor='processes', axis=0, numeric_only: bool = False, dropna=True):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, axis, split_size)
         total = min(split_size, data.shape[1 - axis])
@@ -583,7 +583,7 @@ def parallelize_merge(n_cpu=None, disable_pr_bar=False, split_factor=1,
                 copy: bool = True,
                 indicator: bool = False,
                 validate: str | None = None, ):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, 1, split_size)
         total = min(split_size, data.shape[0])
@@ -611,7 +611,7 @@ def parallelize_isin(n_cpu=None, disable_pr_bar=False, split_factor=1,
                      show_vmem=False):
     @doc(DOC, func='isin')
     def p_isin(data, values):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, 1, split_size)
         total = min(split_size, data.shape[0])
@@ -655,7 +655,7 @@ class ParallelizeStatFunc:
         return progress_udf_wrapper(closure, workers_queue, 1)()
 
     def _parallel_stat_func(self, data, name, kwargs, axis=0, skipna=True, level=None, numeric_only=None):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(self.n_cpu, self.split_factor)
         tasks = get_split_data(data, axis, split_size)
         total = min(split_size, data.shape[1 - axis])
@@ -739,7 +739,7 @@ class ParallelizeStatFuncDdof:
 
     def _parallel_stat_func_ddof(self, data, name, kwargs, axis=0, skipna=True, level=None, ddof=1,
                                  numeric_only=None):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(self.n_cpu, self.split_factor)
         tasks = get_split_data(data, axis, split_size)
         total = min(split_size, data.shape[1 - axis])
@@ -804,7 +804,7 @@ class ParallelizeMinCountStatFunc:
 
     def _parallel_min_count_stat_func(self, data, name, kwargs, axis=0, skipna=True, level=None,
                                       numeric_only=None, min_count=0):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(self.n_cpu, self.split_factor)
         tasks = get_split_data(data, axis, split_size)
         total = min(split_size, data.shape[1 - axis])
@@ -868,7 +868,7 @@ class ParallelizeAccumFunc:
         return progress_udf_wrapper(closure, workers_queue, 1)()
 
     def _parallel_accum_func(self, data, name, args, kwargs, axis=0, skipna=True):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(self.n_cpu, self.split_factor)
         tasks = get_split_data(data, axis, split_size)
         total = min(split_size, data.shape[1 - axis])

--- a/parallel_pandas/core/parallel_groupby.py
+++ b/parallel_pandas/core/parallel_groupby.py
@@ -1,7 +1,7 @@
 from functools import partial
-from multiprocessing import Manager
 
 from .progress_imap import progress_imap
+from .progress_imap import get_workers_queue
 from pandas.core.groupby.ops import _is_indexed_like
 from pandas.util._decorators import doc
 
@@ -62,7 +62,7 @@ def _get_group_iterator(data, include_groups):
 def parallelize_groupby_apply(n_cpu=None, disable_pr_bar=False):
     @doc(DOC, func='apply')
     def p_apply(data, func, executor='processes', include_groups=True, args=(), **kwargs):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         gr_count = data.ngroups
         iterator = _get_group_iterator(data, include_groups)
         dill_func = dill.dumps(func)

--- a/parallel_pandas/core/parallel_series.py
+++ b/parallel_pandas/core/parallel_series.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from functools import partial
-from multiprocessing import Manager
 
 import pandas as pd
 from pandas.util._decorators import doc
@@ -10,6 +9,7 @@ import dill
 
 from .progress_imap import progress_imap
 from .progress_imap import progress_udf_wrapper
+from .progress_imap import get_workers_queue
 from .tools import (
     get_split_data,
     get_split_size,
@@ -30,7 +30,7 @@ def _do_apply(data, dill_func, workers_queue, convert_dtype, args, kwargs):
 def series_parallelize_apply(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
     @doc(DOC, func='apply')
     def p_apply(data, func, executor='processes', convert_dtype=True, args=(), **kwargs):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, 1, split_size)
         dill_func = dill.dumps(func)
@@ -54,7 +54,7 @@ def _do_map(data, dill_arg, workers_queue, na_action):
 def series_parallelize_map(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
     @doc(DOC, func='map')
     def p_map(data, arg, executor='threads', na_action=None):
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, 1, split_size)
         dill_arg = dill.dumps(arg)

--- a/parallel_pandas/core/parallel_window.py
+++ b/parallel_pandas/core/parallel_window.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
-from multiprocessing import cpu_count, Manager
+from multiprocessing import cpu_count
 
 import numpy as np
 import pandas as pd
@@ -9,6 +9,7 @@ from pandas.util._decorators import doc
 import dill
 from .progress_imap import progress_imap
 from .progress_imap import progress_udf_wrapper
+from .progress_imap import get_workers_queue
 from .tools import get_split_data
 from .tools import get_obj_axis
 
@@ -89,7 +90,7 @@ class ParallelRolling:
 
     def parallelize_method(self, data, name, executor, *args, **kwargs):
         attributes = self._get_attributes(data)
-        workers_queue = Manager().Queue()
+        workers_queue = get_workers_queue()
         serialized_flag = False
         if name in ['apply', 'aggregate', 'agg']:
             # if func is callable need to serialize it

--- a/parallel_pandas/core/progress_imap.py
+++ b/parallel_pandas/core/progress_imap.py
@@ -1,5 +1,5 @@
+import atexit
 import time
-from functools import partial
 from itertools import count
 
 import multiprocessing as mp
@@ -7,10 +7,33 @@ from threading import Thread
 
 from tqdm.auto import tqdm
 
-from .tools import _wrapped_func
-
 from psutil import virtual_memory
 from psutil._common import bytes2human
+
+
+_MANAGER = None
+
+
+def _shutdown_manager():
+    global _MANAGER
+    if _MANAGER is not None:
+        _MANAGER.shutdown()
+        _MANAGER = None
+
+
+def get_workers_queue():
+    """Return a progress queue from a shared, lazily-created Manager.
+
+    Spawning a ``multiprocessing.Manager`` starts a server process, which is
+    costly. parallel-pandas runs many small operations in a row, so instead of
+    creating a Manager on every call we create it once and hand out fresh
+    queues from it.
+    """
+    global _MANAGER
+    if _MANAGER is None:
+        _MANAGER = mp.Manager()
+        atexit.register(_shutdown_manager)
+    return _MANAGER.Queue()
 
 
 class ProgressBar(tqdm):
@@ -104,26 +127,18 @@ def _do_parallel(func, tasks, initializer, initargs, n_cpu, total, disable, show
     else:
         exc_pool = mp.Pool(n_cpu, initializer=initializer, initargs=initargs)
     with exc_pool as p:
-        result = list()
-        iter_result = p.imap(func, tasks)
-        while 1:
-            try:
-                result.append(next(iter_result))
-            except StopIteration:
-                break
+        result = list(p.imap(func, tasks))
     q.put((None, None))
     thread_.join()
     return result
 
 
 def progress_imap(func, tasks, q, executor='threads', initializer=None, initargs=(), n_cpu=None, total=None,
-                  disable=False, process_timeout=None, show_vmem=False, desc=''
+                  disable=False, show_vmem=False, desc=''
                   ):
     if executor not in ['threads', 'processes']:
         raise ValueError('Invalid executor value specified. Must be one of the values: "threads", "processes"')
     try:
-        if process_timeout:
-            func = partial(_wrapped_func, func, process_timeout, True)
         result = _do_parallel(func, tasks, initializer, initargs, n_cpu, total, disable, show_vmem, q, executor, desc)
     except (KeyboardInterrupt, Exception):
         q.put((None, None))

--- a/parallel_pandas/core/tools.py
+++ b/parallel_pandas/core/tools.py
@@ -1,16 +1,8 @@
-import _thread as thread
-import threading
 from multiprocessing import cpu_count
-from functools import wraps
 from concurrent.futures import ThreadPoolExecutor
-
-import platform
-import signal
-import os
 
 import pandas as pd
 import numpy as np
-import time
 
 
 def get_time_chunks(data, window, n_chunks):
@@ -42,16 +34,6 @@ def get_time_chunks(data, window, n_chunks):
         cut_times.append(cut_time)
 
     return chunks, cut_times
-
-
-def time_of_function(function):
-    def wrapped(*args, **kwargs):
-        start_time = time.time()
-        res = function(*args, **kwargs)
-        print('Time of function {} is {:.3f} s.'.format(function.__name__, time.time() - start_time))
-        return res
-
-    return wrapped
 
 
 def get_pandas_version():
@@ -100,36 +82,3 @@ def get_split_data(df, axis, split_size, offset=0):
     idx_split = np.array_split(np.arange(df.shape[1 - axis]), split_size)
     tasks = iterate_by_df(df, idx_split, axis, offset)
     return tasks
-
-
-def stop_function():
-    if platform.system() == 'Windows':
-        thread.interrupt_main()
-    else:
-        os.kill(os.getpid(), signal.SIGINT)
-
-
-def stopit_after_timeout(s, raise_exception=True):
-    def actual_decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            timer = threading.Timer(s, stop_function)
-            try:
-                timer.start()
-                result = func(*args, **kwargs)
-            except KeyboardInterrupt:
-                msg = f'function \"{func.__name__}\" took longer than {s} s.'
-                if raise_exception:
-                    raise TimeoutError(msg)
-                result = msg
-            finally:
-                timer.cancel()
-            return result
-
-        return wrapper
-
-    return actual_decorator
-
-
-def _wrapped_func(func, s, raise_exception, *args, **kwargs):
-    return stopit_after_timeout(s, raise_exception=raise_exception)(func)(*args, **kwargs)


### PR DESCRIPTION
Deduplicates and speeds up the progress engine (Variant B from the parallelbar comparison) without adding a dependency.

## Summary
- Reuse a single lazily-created `multiprocessing.Manager` for the progress queue instead of spawning a new Manager server process on each of the ~24 call sites. This removes most per-operation overhead (local test suite runtime dropped ~7.6s -> ~4.3s).
- Remove the never-wired `process_timeout` path and the unused `stopit_after_timeout` / `_wrapped_func` / `stop_function` / `time_of_function` helpers and their imports.
- Simplify `_do_parallel`'s manual imap loop to `list(p.imap(...))`.

## Test plan
- `pytest tests/` green locally on pandas 2.2.3 and 3.0.3 (75 passed).
- CI matrix (2.1.4 / 2.2.3 / 3.0.3 / numba) must pass.