### PR TITLE
Allow redirecting the progress bar to a logger (closes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ When initializing parallel-pandas you can specify the following options:
 2. `split_factor` - Affects the number of chunks into which the DataFrame/Series is split according to the formula `chunks_number = split_factor*n_cpu` (default 1).
 3. `show_vmem` - Shows a progress bar with available RAM (default `False`)
 4. `disable_pr_bar` - Disable the progress bar for parallel tasks (default `False`)
+5. `logger` - A `logging.Logger` the progress bar is redirected to instead of the terminal (default `None`). Optionally set the level with `logger_level` (default `logging.INFO`). To write the bar to an arbitrary file-like object instead, pass `pbar_file`.
 
 For example
 
@@ -66,6 +67,19 @@ df = pd.DataFrame(np.random.random((1_000_000, 100)))
 ![](https://raw.githubusercontent.com/dubovikmaster/parallel-pandas/master/gifs/p_describe.gif)
 
 During initialization, we specified `split_factor=4` and `n_cpu = 16`, so the DataFrame will be split into 64 chunks (in the case of the `describe` method, axis = 1) and the progress bar shows the progress for each chunk
+
+### Redirecting the progress bar to a logger
+
+By default the progress bar is written to the terminal. In non-interactive environments (log files, JSON logs, schedulers) you can redirect it to a `logging.Logger` — each bar refresh is emitted as a log record:
+
+```python
+import logging
+from parallel_pandas import ParallelPandas
+
+logging.basicConfig(filename="progress.log", level=logging.INFO)
+ParallelPandas.initialize(logger=logging.getLogger("pp"))
+# df.p_apply(...) now writes the bar into progress.log instead of the terminal
+```
 
 You can parallelize any expression with pandas Dataframe. For example, let's do a z-score normalization of columns in a dataframe. Let's look at the execution time and memory consumption. Compare with synchronous execution and with Dask.DataFrame
 ```python

--- a/parallel_pandas/__init__.py
+++ b/parallel_pandas/__init__.py
@@ -1,3 +1,4 @@
 from .main import ParallelPandas
+from .core.progress_imap import TqdmToLogger, set_progress_bar_file
 
-__all__ = ['ParallelPandas']
+__all__ = ['ParallelPandas', 'TqdmToLogger', 'set_progress_bar_file']

--- a/parallel_pandas/core/progress_imap.py
+++ b/parallel_pandas/core/progress_imap.py
@@ -1,4 +1,6 @@
 import atexit
+import io
+import logging
 import time
 from itertools import count
 
@@ -12,6 +14,39 @@ from psutil._common import bytes2human
 
 
 _MANAGER = None
+
+# Where the progress bars write. ``None`` means the tqdm default (stderr).
+# Can be any file-like object, e.g. a TqdmToLogger to redirect the bar to a logger.
+_PROGRESS_FILE = None
+
+
+def set_progress_bar_file(file):
+    """Set the file-like object the progress bars write to (None = tqdm default)."""
+    global _PROGRESS_FILE
+    _PROGRESS_FILE = file
+
+
+class TqdmToLogger(io.StringIO):
+    """File-like object that redirects tqdm progress-bar output to a logging.Logger.
+
+    tqdm writes the rendered bar and flushes on every refresh; each flush is emitted
+    as one log record, so the bar shows up in the configured logging handlers
+    (files, JSON logs, non-tty environments, ...) instead of the terminal.
+    """
+
+    def __init__(self, logger, level=logging.INFO):
+        super().__init__()
+        self.logger = logger
+        self.level = level
+        self._buf = ''
+
+    def write(self, buf):
+        self._buf = buf.strip('\r\n\t ')
+        return len(buf)
+
+    def flush(self):
+        if self._buf:
+            self.logger.log(self.level, self._buf)
 
 
 def _shutdown_manager():
@@ -92,13 +127,14 @@ def progress_udf_wrapper(func, workers_queue, total):
 
 
 def _process_status(bar_size, disable, show_vmem, desc, q):
-    bar = ProgressBar(total=bar_size, disable=disable, desc=desc + ' DONE')
+    pbar_file = _PROGRESS_FILE
+    bar = ProgressBar(total=bar_size, disable=disable, desc=desc + ' DONE', file=pbar_file)
     vmem = virtual_memory()
     if show_vmem:
         vmem_pbar = MemoryProgressBar(range(100),
                                       bar_format="{desc}: {percentage:.1f}%|{bar}|  " + bytes2human(vmem.total),
                                       initial=vmem.percent, colour='green', position=1, desc='VMEM USAGE',
-                                      disable=disable,
+                                      disable=disable, file=pbar_file,
                                       )
         vmem_pbar.refresh()
     while True:

--- a/parallel_pandas/main.py
+++ b/parallel_pandas/main.py
@@ -1,6 +1,9 @@
+import logging
+
 import pandas as pd
 
 from .core.tools import get_pandas_version
+from .core.progress_imap import TqdmToLogger, set_progress_bar_file
 
 from .core import series_parallelize_apply
 from .core import series_parallelize_map
@@ -46,7 +49,17 @@ PD_VERSION = MAJOR*10 + MINOR
 
 class ParallelPandas:
     @staticmethod
-    def initialize(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
+    def initialize(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1,
+                   logger=None, logger_level=logging.INFO, pbar_file=None):
+        # Route the progress bars: an explicit file-like wins, otherwise a logging.Logger
+        # is wrapped so the bars are emitted as log records, otherwise the tqdm default.
+        if pbar_file is not None:
+            set_progress_bar_file(pbar_file)
+        elif logger is not None:
+            set_progress_bar_file(TqdmToLogger(logger, level=logger_level))
+        else:
+            set_progress_bar_file(None)
+
         # add parallel methods to Series
         pd.Series.p_apply = series_parallelize_apply(n_cpu=n_cpu, disable_pr_bar=disable_pr_bar, show_vmem=show_vmem,
                                                      split_factor=split_factor)

--- a/tests/test_progress_logger.py
+++ b/tests/test_progress_logger.py
@@ -1,0 +1,75 @@
+import logging
+
+import pandas as pd
+import pytest
+
+from parallel_pandas import ParallelPandas, TqdmToLogger
+from parallel_pandas.core import progress_imap
+
+
+@pytest.fixture
+def restore_pp():
+    """Restore the shared configuration the rest of the suite relies on."""
+    yield
+    ParallelPandas.initialize(n_cpu=4, disable_pr_bar=True, split_factor=2)
+
+
+class _CollectHandler(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.messages = []
+
+    def emit(self, record):
+        self.messages.append(record.getMessage())
+
+
+def test_tqdm_to_logger_write_flush():
+    logger = logging.getLogger("parallel_pandas.test.direct")
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    handler = _CollectHandler()
+    logger.addHandler(handler)
+    try:
+        out = TqdmToLogger(logger)
+        out.write("\r  50%|#####     | progress")
+        out.flush()
+        out.write("\r\n")  # whitespace only -> nothing logged
+        out.flush()
+    finally:
+        logger.removeHandler(handler)
+    assert handler.messages == ["50%|#####     | progress"]
+
+
+def test_progress_redirected_to_logger(rng, restore_pp):
+    logger = logging.getLogger("parallel_pandas.test.pbar")
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    handler = _CollectHandler()
+    logger.addHandler(handler)
+    try:
+        ParallelPandas.initialize(n_cpu=2, disable_pr_bar=False, split_factor=2, logger=logger)
+        df = pd.DataFrame(rng.standard_normal((300, 8)))
+        df.p_apply(lambda x: x.mean())
+    finally:
+        logger.removeHandler(handler)
+
+    assert handler.messages, "expected the progress bar to emit at least one log record"
+    assert any("DONE" in m for m in handler.messages)
+
+
+def test_default_output_when_no_logger(rng, restore_pp):
+    ParallelPandas.initialize(n_cpu=2, disable_pr_bar=True, split_factor=2)
+    assert progress_imap._PROGRESS_FILE is None
+    df = pd.DataFrame(rng.standard_normal((120, 4)))
+    result = df.p_apply(lambda x: x.sum())
+    assert len(result) == 4
+
+
+def test_pbar_file_takes_precedence_over_logger(rng, restore_pp):
+    import io
+
+    buffer = io.StringIO()
+    logger = logging.getLogger("parallel_pandas.test.precedence")
+    ParallelPandas.initialize(n_cpu=2, disable_pr_bar=True, split_factor=2,
+                              logger=logger, pbar_file=buffer)
+    assert progress_imap._PROGRESS_FILE is buffer


### PR DESCRIPTION
Addresses #15: a way to send the `p_*` progress bars to a logger instead of the terminal.

## What
`ParallelPandas.initialize(...)` gains three optional arguments:
- `logger` — a `logging.Logger`; the progress bars are wrapped in a new `TqdmToLogger` file-like and emitted as log records.
- `logger_level` — level used for those records (default `logging.INFO`).
- `pbar_file` — an explicit file-like to write the bars to (takes precedence over `logger`).

```python
import logging
from parallel_pandas import ParallelPandas

logging.basicConfig(filename='progress.log', level=logging.INFO)
ParallelPandas.initialize(logger=logging.getLogger('pp'))
# df.p_apply(...) now writes the bar into progress.log
```

`TqdmToLogger` and `set_progress_bar_file` are exported at the package top level for manual/advanced use.

## How
The bar output target is a single module-level setting in `progress_imap` read by the status thread. That thread runs in the **main** process (only progress *increments* travel through the worker queue), so a logger/file object can be used directly — no per-call plumbing and nothing needs to be pickled to workers.

## Test plan
- `tests/test_progress_logger.py`: `TqdmToLogger.write/flush` behavior; a real `p_apply` with `logger=` emits `... DONE` records to the logger; default (no logger) leaves output on the tqdm default; `pbar_file` precedence over `logger`.
- Full suite green locally on pandas 2.2.3 and 3.0.3 (97 passed).