### PR TITLE
Fix NameError for udfs using third-party globals in workers (closes #13)

### DIFF
--- a/parallel_pandas/core/parallel_dataframe.py
+++ b/parallel_pandas/core/parallel_dataframe.py
@@ -48,7 +48,7 @@ def parallelize_apply(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_f
         workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, axis, split_size)
-        dill_func = dill.dumps(func)
+        dill_func = dill.dumps(func, recurse=True)
         result = progress_imap(partial(_do_apply, axis=axis, raw=raw, result_type=result_type, dill_func=dill_func,
                                        workers_queue=workers_queue, args=args, kwargs=kwargs),
                                tasks, workers_queue, n_cpu=n_cpu, total=data.shape[1 - axis], disable=disable_pr_bar,
@@ -83,7 +83,7 @@ def parallelize_chunk_apply(n_cpu=None, disable_pr_bar=False, show_vmem=False, s
             tasks = (pd.concat([group.get_group(j) for j in i], copy=False) for i in idx_split)
         else:
             tasks = get_split_data(data, 1 - axis, split_size)
-        dill_func = dill.dumps(func)
+        dill_func = dill.dumps(func, recurse=True)
         result = progress_imap(partial(_do_chunk_apply, dill_func=dill_func,
                                        workers_queue=workers_queue, args=args, kwargs=kwargs),
                                tasks, workers_queue, n_cpu=n_cpu, total=split_size, disable=disable_pr_bar,
@@ -165,7 +165,7 @@ def parallelize_pivot_table(n_cpu=None, disable_pr_bar=False, show_vmem=False, s
         # fill_value / sort are applied once on the combined frame, not per chunk:
         # a cross-chunk missing (index, column) cell is only introduced by the concat.
         chunk_kwargs = dict(pivot_kwargs, fill_value=None, sort=False)
-        dill_kwargs = dill.dumps(chunk_kwargs)
+        dill_kwargs = dill.dumps(chunk_kwargs, recurse=True)
         result = progress_imap(partial(_do_pivot_table, dill_kwargs=dill_kwargs, workers_queue=workers_queue),
                                tasks, workers_queue, n_cpu=n_cpu, total=split_size, disable=disable_pr_bar,
                                show_vmem=show_vmem, executor=executor, desc='PIVOT_TABLE')
@@ -346,7 +346,7 @@ def parallelize_aggregate(n_cpu=None, disable_pr_bar=False, show_vmem=False, spl
         dilled_func = False
         if callable(func):
             dilled_func = True
-            func = dill.dumps(func)
+            func = dill.dumps(func, recurse=True)
         result = progress_imap(partial(_do_aggregate, axis=axis, func=func,
                                        workers_queue=workers_queue, dilled_func=dilled_func, args=args, kwargs=kwargs),
                                tasks, workers_queue, n_cpu=n_cpu, total=split_size, disable=disable_pr_bar,
@@ -396,7 +396,7 @@ def parallelize_applymap(n_cpu=None, disable_pr_bar=False, show_vmem=False, spli
         workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, 1, split_size)
-        dill_func = dill.dumps(func)
+        dill_func = dill.dumps(func, recurse=True)
         result = progress_imap(
             partial(do_applymap, workers_queue=workers_queue, dill_func=dill_func, na_action=na_action,
                     kwargs=kwargs), tasks, workers_queue, n_cpu=n_cpu, disable=disable_pr_bar, show_vmem=show_vmem,
@@ -418,7 +418,7 @@ def parallelize_map(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_fac
         workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, 1, split_size)
-        dill_func = dill.dumps(func)
+        dill_func = dill.dumps(func, recurse=True)
         result = progress_imap(
             partial(do_map, workers_queue=workers_queue, dill_func=dill_func, na_action=na_action,
                     kwargs=kwargs), tasks, workers_queue, n_cpu=n_cpu, disable=disable_pr_bar, show_vmem=show_vmem,

--- a/parallel_pandas/core/parallel_groupby.py
+++ b/parallel_pandas/core/parallel_groupby.py
@@ -65,7 +65,7 @@ def parallelize_groupby_apply(n_cpu=None, disable_pr_bar=False):
         workers_queue = get_workers_queue()
         gr_count = data.ngroups
         iterator = _get_group_iterator(data, include_groups)
-        dill_func = dill.dumps(func)
+        dill_func = dill.dumps(func, recurse=True)
         result = progress_imap(
             partial(_do_group_apply, dill_func=dill_func, workers_queue=workers_queue, args=args, kwargs=kwargs),
             iterator, workers_queue, total=gr_count, n_cpu=n_cpu, disable=disable_pr_bar, executor=executor,

--- a/parallel_pandas/core/parallel_series.py
+++ b/parallel_pandas/core/parallel_series.py
@@ -33,7 +33,7 @@ def series_parallelize_apply(n_cpu=None, disable_pr_bar=False, show_vmem=False, 
         workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, 1, split_size)
-        dill_func = dill.dumps(func)
+        dill_func = dill.dumps(func, recurse=True)
         result = progress_imap(partial(_do_apply, convert_dtype=convert_dtype, dill_func=dill_func,
                                        workers_queue=workers_queue, args=args, kwargs=kwargs),
                                tasks, workers_queue, n_cpu=n_cpu, total=data.shape[0], disable=disable_pr_bar,
@@ -57,7 +57,7 @@ def series_parallelize_map(n_cpu=None, disable_pr_bar=False, show_vmem=False, sp
         workers_queue = get_workers_queue()
         split_size = get_split_size(n_cpu, split_factor)
         tasks = get_split_data(data, 1, split_size)
-        dill_arg = dill.dumps(arg)
+        dill_arg = dill.dumps(arg, recurse=True)
         result = progress_imap(partial(_do_map, dill_arg=dill_arg,
                                        workers_queue=workers_queue, na_action=na_action),
                                tasks, workers_queue, n_cpu=n_cpu, total=split_size, disable=disable_pr_bar,

--- a/parallel_pandas/core/parallel_window.py
+++ b/parallel_pandas/core/parallel_window.py
@@ -75,7 +75,7 @@ class ParallelRolling:
     @staticmethod
     def _func_serialize(func):
         if callable(func):
-            return dill.dumps(func), True
+            return dill.dumps(func, recurse=True), True
         return func, False
 
     @staticmethod

--- a/tests/test_apply_globals.py
+++ b/tests/test_apply_globals.py
@@ -1,0 +1,58 @@
+import subprocess
+import sys
+import textwrap
+
+
+# Regression test for https://github.com/dubovikmaster/parallel-pandas/issues/13
+# A user function passed to p_apply references a third-party module (numpy) via a
+# module global. Under the "spawn" start method the function is shipped to worker
+# processes; without dill's recurse=True the referenced global is lost and the
+# worker raises `NameError: name 'np' is not defined`.
+#
+# The failure only shows up for a function living in a __main__ script (an importable
+# test module would make the global available in the workers anyway), so we run a real
+# script in a subprocess and assert it completes.
+_SCRIPT = textwrap.dedent(
+    '''
+    import numpy as np
+    import pandas as pd
+    from parallel_pandas import ParallelPandas
+
+
+    def rolling_udf(x):
+        return np.nansum(x) - np.nanmean(x)
+
+
+    def row_udf(row):
+        return np.nanmax(row) - np.nanmin(row)
+
+
+    if __name__ == "__main__":
+        ParallelPandas.initialize(n_cpu=2, disable_pr_bar=True)
+        df = pd.DataFrame(np.random.random((500, 4)))
+
+        r1 = df.rolling(10).p_apply(rolling_udf, raw=True, executor="processes")
+        assert r1.shape == (500, 4)
+
+        r2 = df.p_apply(row_udf, axis=1, executor="processes")
+        assert len(r2) == 500
+
+        s = pd.Series(np.random.random(500))
+        r3 = s.p_apply(lambda v: np.expm1(v), executor="processes")
+        assert len(r3) == 500
+
+        print("SUCCESS")
+    '''
+)
+
+
+def test_apply_with_third_party_global(tmp_path):
+    script = tmp_path / "job.py"
+    script.write_text(_SCRIPT)
+    proc = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    assert "SUCCESS" in proc.stdout


### PR DESCRIPTION
Fixes #13: `rolling(30).p_apply(func)` (and other `p_apply`/`p_agg`/`pivot_table` paths) raised `NameError: name 'np' is not defined` when the user function referenced a module global such as `numpy`.

## Root cause
User functions are shipped to worker processes with `dill`. Under the `spawn` start method (default on macOS/Windows) a function defined in a `__main__` script loses its module globals during serialization, so a udf that uses e.g. `np` fails inside the worker.

## Fix
Serialize callables with `dill.dumps(..., recurse=True)`, which traces and embeds the globals the function actually references. Applied to every `dill.dumps` call site: window (`_func_serialize`), DataFrame (`p_apply`, `chunk_apply`, `p_agg`, `p_map`, `pivot_table`), Series (`p_apply`, `p_isin`) and groupby apply.

## Reproduction (before the fix)
```python
import numpy as np, pandas as pd
from parallel_pandas import ParallelPandas

def f(x):
    return np.nansum(x)

if __name__ == '__main__':
    ParallelPandas.initialize(n_cpu=4, disable_pr_bar=True)
    df = pd.DataFrame(np.random.random((2000, 4)))
    df.rolling(30).p_apply(f, raw=True, executor='processes')  # NameError: name 'np' is not defined
```

## Test plan
- New `tests/test_apply_globals.py` runs a real `__main__` script in a subprocess whose udf uses numpy across `rolling.p_apply`, `DataFrame.p_apply` and `Series.p_apply`; it fails on the old code and passes with the fix. (The scenario only reproduces from a `__main__` script, not from an importable test module, hence the subprocess.)
- Full suite green locally on pandas 2.2.3 and 3.0.3 (98 passed).