### PR TITLE
Lower supported pandas floor to 2.0 (and test it in CI)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@ jobs:
       matrix:
         include:
           - python: "3.10"
+            pandas: "2.0.3"
+            numpy: "<2"
+          - python: "3.10"
             pandas: "2.1.4"
             numpy: "<2"
           - python: "3.11"
@@ -63,23 +66,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install ".[test,numba]"
           pip install "pandas==2.2.3"
-      - name: Run tests
-        run: pytest tests/ -q
-
-  # pandas 3.0 is not officially supported yet; track it without blocking CI.
-  test-future:
-    name: py3.12 / pandas latest (allowed to fail)
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install package with newest pandas
-        run: |
-          python -m pip install --upgrade pip
-          pip install ".[test]"
-          pip install --upgrade pandas
       - name: Run tests
         run: pytest tests/ -q

--- a/parallel_pandas/core/parallel_window.py
+++ b/parallel_pandas/core/parallel_window.py
@@ -17,6 +17,15 @@ DOC = 'Parallel analogue of the {func} method\nSee pandas DataFrame docstring fo
       'information\nhttps://pandas.pydata.org/docs/reference/window.html'
 
 
+def _get_gb_grouper(data):
+    # `_grouper` on grouped-window objects only exists since pandas 2.2;
+    # older versions (2.0/2.1) expose it as the public `grouper` attribute.
+    grouper = getattr(data, '_grouper', None)
+    if grouper is None:
+        grouper = data.grouper
+    return grouper
+
+
 class ParallelRolling:
     def __init__(self, n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
         self.n_cpu = n_cpu if n_cpu else cpu_count()
@@ -82,6 +91,7 @@ class ParallelRolling:
     def _get_attributes(data):
         attributes = {attribute: getattr(data, attribute) for attribute in data._attributes}
         attributes.pop("_grouper", None)
+        attributes.pop("grouper", None)
         # `axis` is handled separately and was removed from window ctors in pandas 3.
         attributes.pop("axis", None)
         if attributes.get('win_type') == 'freq':
@@ -307,14 +317,15 @@ class ParallelGroupbyMixin(ParallelRolling):
         return progress_udf_wrapper(foo, workers_queue, 1)()
 
     def _get_split_data(self, data):
-        return data._grouper.get_iterator(data.obj)
+        return _get_gb_grouper(data).get_iterator(data.obj)
 
     def _get_total_tasks(self, data):
-        return data._grouper.ngroups
+        return _get_gb_grouper(data).ngroups
 
     def _data_reduce(self, result, data, axis, offset):
+        grouper = _get_gb_grouper(data)
         out = pd.concat(result)
-        out.rename_axis(data._grouper.names + [data._grouper.axis.name], inplace=True)
+        out.rename_axis(grouper.names + [grouper.axis.name], inplace=True)
         return out
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-  "pandas>=2.1.0",
+  "pandas>=2.0.0",
   "dill",
   "psutil",
   "tqdm",


### PR DESCRIPTION
Lowers the declared minimum pandas from 2.1 to 2.0 and verifies it in CI.

## Why
The 2.1 floor was a *verifiable* floor (lowest version in CI), not a hard technical requirement — the code already carries `<2.2` compatibility branches (public `grouper` fallback, 3-arg `_is_indexed_like`, version-aware `include_groups`, `applymap`/`map` split). This drops the floor to 2.0 and adds it to the matrix so the claim is actually tested.

## Changes
- `pyproject.toml`: `pandas>=2.0.0` (was `>=2.1.0`).
- CI: add a `py3.10 / pandas 2.0.3` entry (with `numpy<2`); remove the now-redundant allowed-to-fail `test-future` job (pandas 3.0.3 is already a first-class matrix entry).
- Grouped-window methods: read the grouper through a `_grouper`→`grouper` fallback (the private `_grouper` only exists since pandas 2.2) and also strip the public `grouper` key from the reconstructed window kwargs, so `gb.rolling(...).p_*` works on 2.0/2.1.

## Test plan
- Local: full suite green on pandas 2.1.1, 2.2.3 and 3.0.3 (98 passed each). 2.1.1 exercises the same `<2.2` branches as 2.0.
- pandas 2.0.3 has no wheels for Python 3.12 (local interpreter), so it is verified on CI (py3.10). Merging is gated on the full matrix going green.