### PR TITLE
perf: warm worker pools (reuse across calls)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ When initializing parallel-pandas you can specify the following options:
 3. `show_vmem` - Shows a progress bar with available RAM (default `False`)
 4. `disable_pr_bar` - Disable the progress bar for parallel tasks (default `False`)
 5. `logger` - A `logging.Logger` the progress bar is redirected to instead of the terminal (default `None`). Optionally set the level with `logger_level` (default `logging.INFO`). To write the bar to an arbitrary file-like object instead, pass `pbar_file`.
+6. `reuse_pool` - Keep the worker pool warm and reuse it across calls instead of spawning a new one every time (default `True`). This removes the per-call process-spawn overhead, which makes a big difference when you call process-based methods (`p_apply`, `p_map`, `chunk_apply`, `p_pivot_table`, groupby `p_apply`, ...) repeatedly. Set it to `False` to restore per-call pool creation.
 
 For example
 

--- a/parallel_pandas/__init__.py
+++ b/parallel_pandas/__init__.py
@@ -1,4 +1,4 @@
 from .main import ParallelPandas
-from .core.progress_imap import TqdmToLogger, set_progress_bar_file
+from .core.progress_imap import TqdmToLogger, set_progress_bar_file, set_reuse_pool
 
-__all__ = ['ParallelPandas', 'TqdmToLogger', 'set_progress_bar_file']
+__all__ = ['ParallelPandas', 'TqdmToLogger', 'set_progress_bar_file', 'set_reuse_pool']

--- a/parallel_pandas/core/progress_imap.py
+++ b/parallel_pandas/core/progress_imap.py
@@ -15,6 +15,13 @@ from psutil._common import bytes2human
 
 _MANAGER = None
 
+# Cache of worker pools, keyed by (executor, n_cpu), so consecutive parallel
+# operations reuse the same warm workers instead of paying the spawn cost every
+# call. See ``_get_pool``/``set_reuse_pool``.
+_POOLS = {}
+_REUSE_POOL = True
+_POOLS_ATEXIT_REGISTERED = False
+
 # Where the progress bars write. ``None`` means the tqdm default (stderr).
 # Can be any file-like object, e.g. a TqdmToLogger to redirect the bar to a logger.
 _PROGRESS_FILE = None
@@ -54,6 +61,68 @@ def _shutdown_manager():
     if _MANAGER is not None:
         _MANAGER.shutdown()
         _MANAGER = None
+
+
+def _create_pool(executor, n_cpu, initializer, initargs):
+    if executor == 'threads':
+        return mp.pool.ThreadPool(n_cpu, initializer=initializer, initargs=initargs)
+    return mp.Pool(n_cpu, initializer=initializer, initargs=initargs)
+
+
+def _shutdown_pools():
+    global _POOLS
+    for pool in list(_POOLS.values()):
+        try:
+            pool.terminate()
+        except Exception:
+            pass
+    _POOLS = {}
+
+
+def _drop_pool(executor, n_cpu):
+    """Discard a (possibly broken) cached pool so the next call spawns a fresh one."""
+    pool = _POOLS.pop((executor, n_cpu), None)
+    if pool is not None:
+        try:
+            pool.terminate()
+        except Exception:
+            pass
+
+
+def set_reuse_pool(flag):
+    """Enable/disable reusing worker pools across parallel operations.
+
+    When enabled (default) the worker pool for a given ``(executor, n_cpu)`` is
+    created once and kept warm for the lifetime of the process, which removes the
+    per-call process-spawn overhead. Disabling it restores the old behaviour of
+    creating and tearing down a pool on every call and closes any warm pools.
+    """
+    global _REUSE_POOL
+    _REUSE_POOL = bool(flag)
+    if not _REUSE_POOL:
+        _shutdown_pools()
+
+
+def _get_pool(executor, n_cpu, initializer, initargs):
+    """Return ``(pool, reused)``.
+
+    Only the common case (no custom ``initializer``) is cached, because a cached
+    pool runs its initializer exactly once at creation and cannot honour a
+    different one on a later call. ``reused=True`` means the caller must NOT close
+    the pool afterwards.
+    """
+    global _POOLS_ATEXIT_REGISTERED
+    if not _REUSE_POOL or initializer is not None:
+        return _create_pool(executor, n_cpu, initializer, initargs), False
+    key = (executor, n_cpu)
+    pool = _POOLS.get(key)
+    if pool is None:
+        pool = _create_pool(executor, n_cpu, None, initargs)
+        _POOLS[key] = pool
+        if not _POOLS_ATEXIT_REGISTERED:
+            atexit.register(_shutdown_pools)
+            _POOLS_ATEXIT_REGISTERED = True
+    return pool, True
 
 
 def get_workers_queue():
@@ -158,12 +227,19 @@ def _do_parallel(func, tasks, initializer, initargs, n_cpu, total, disable, show
         n_cpu = mp.cpu_count()
     thread_ = Thread(target=_process_status, args=(total, disable, show_vmem, desc, q))
     thread_.start()
-    if executor == 'threads':
-        exc_pool = mp.pool.ThreadPool(n_cpu, initializer=initializer, initargs=initargs)
-    else:
-        exc_pool = mp.Pool(n_cpu, initializer=initializer, initargs=initargs)
-    with exc_pool as p:
-        result = list(p.imap(func, tasks))
+    pool, reused = _get_pool(executor, n_cpu, initializer, initargs)
+    try:
+        result = list(pool.imap(func, tasks))
+    except BaseException:
+        # A reused pool may be left in a broken state (e.g. a worker died), so drop
+        # it to guarantee the next call starts from a healthy pool.
+        if reused:
+            _drop_pool(executor, n_cpu)
+        raise
+    finally:
+        if not reused:
+            pool.close()
+            pool.join()
     q.put((None, None))
     thread_.join()
     return result

--- a/parallel_pandas/main.py
+++ b/parallel_pandas/main.py
@@ -3,7 +3,7 @@ import logging
 import pandas as pd
 
 from .core.tools import get_pandas_version
-from .core.progress_imap import TqdmToLogger, set_progress_bar_file
+from .core.progress_imap import TqdmToLogger, set_progress_bar_file, set_reuse_pool
 
 from .core import series_parallelize_apply
 from .core import series_parallelize_map
@@ -50,7 +50,11 @@ PD_VERSION = MAJOR*10 + MINOR
 class ParallelPandas:
     @staticmethod
     def initialize(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1,
-                   logger=None, logger_level=logging.INFO, pbar_file=None):
+                   logger=None, logger_level=logging.INFO, pbar_file=None, reuse_pool=True):
+        # Keep worker pools warm across calls (removes the per-call process-spawn
+        # overhead). Set reuse_pool=False to restore per-call pool creation.
+        set_reuse_pool(reuse_pool)
+
         # Route the progress bars: an explicit file-like wins, otherwise a logging.Logger
         # is wrapped so the bars are emitted as log records, otherwise the tqdm default.
         if pbar_file is not None:

--- a/tests/test_warm_pool.py
+++ b/tests/test_warm_pool.py
@@ -1,0 +1,90 @@
+import pandas as pd
+import pytest
+
+from parallel_pandas import set_reuse_pool
+from parallel_pandas.core import progress_imap as pi
+
+
+def _square(x):
+    return x * x
+
+
+@pytest.fixture(autouse=True)
+def _reset_pools():
+    """Every test starts and ends with a clean, reuse-enabled pool cache."""
+    pi._shutdown_pools()
+    set_reuse_pool(True)
+    yield
+    pi._shutdown_pools()
+    set_reuse_pool(True)
+
+
+def _run(executor, n_cpu=2):
+    q = pi.get_workers_queue()
+    tasks = list(range(20))
+    return pi.progress_imap(
+        _square, tasks, q, executor=executor, n_cpu=n_cpu, total=len(tasks), disable=True
+    )
+
+
+@pytest.mark.parametrize("executor", ["threads", "processes"])
+def test_results_are_correct(executor):
+    assert _run(executor) == [x * x for x in range(20)]
+
+
+@pytest.mark.parametrize("executor", ["threads", "processes"])
+def test_pool_is_reused_across_calls(executor):
+    _run(executor)
+    pool_first = pi._POOLS[(executor, 2)]
+    _run(executor)
+    pool_second = pi._POOLS[(executor, 2)]
+    assert pool_first is pool_second
+    assert len(pi._POOLS) == 1
+
+
+def test_pools_keyed_by_executor_and_ncpu():
+    _run("threads", n_cpu=2)
+    _run("processes", n_cpu=2)
+    _run("threads", n_cpu=3)
+    assert set(pi._POOLS) == {("threads", 2), ("processes", 2), ("threads", 3)}
+
+
+@pytest.mark.parametrize("executor", ["threads", "processes"])
+def test_reuse_disabled_does_not_cache(executor):
+    set_reuse_pool(False)
+    assert _run(executor) == [x * x for x in range(20)]
+    assert pi._POOLS == {}
+
+
+def test_disabling_shuts_down_existing_pools():
+    _run("threads")
+    assert pi._POOLS
+    set_reuse_pool(False)
+    assert pi._POOLS == {}
+
+
+@pytest.mark.parametrize("executor", ["threads", "processes"])
+def test_broken_pool_is_dropped_and_recreated(executor):
+    _run(executor)
+    broken = pi._POOLS[(executor, 2)]
+    broken.terminate()
+    broken.join()
+    # A call against the terminated pool must eventually leave the cache healthy:
+    # either it raises and drops the pool, or (threads) it just recreates cleanly.
+    try:
+        _run(executor)
+    except Exception:
+        pass
+    # After recovery a subsequent call always succeeds with a fresh pool.
+    assert _run(executor) == [x * x for x in range(20)]
+    assert pi._POOLS[(executor, 2)] is not broken
+
+
+def test_repeated_p_apply_warm(df):
+    # Two consecutive process-executor applies must both work with a warm pool
+    # and agree with pandas.
+    expected = df.apply(lambda row: row.sum(), axis=1)
+    r1 = df.p_apply(lambda row: row.sum(), axis=1, executor="processes")
+    r2 = df.p_apply(lambda row: row.sum(), axis=1, executor="processes")
+    pd.testing.assert_series_equal(r1, expected)
+    pd.testing.assert_series_equal(r2, expected)


### PR DESCRIPTION
## Summary
- Keep worker pools warm: cache `Pool`/`ThreadPool` by `(executor, n_cpu)` and reuse them for the process lifetime instead of creating/tearing one down on every parallel call.
- Removes the per-call process-spawn overhead that dominated process-based methods (`p_apply`, `p_map`, `chunk_apply`, `p_pivot_table`, groupby `p_apply`, ...), especially on macOS `spawn`.
- Self-healing: if a reused pool becomes broken (e.g. a worker dies) it is dropped so the next call spawns a fresh one.
- Enabled by default (consistent with the already-shared `Manager`); opt out with `ParallelPandas.initialize(reuse_pool=False)` or `set_reuse_pool(False)`.

## Benchmark (local, 8 cpu, repeated process `p_apply`)
| | per call |
|---|---|
| cold (reuse_pool=False) | ~909 ms |
| warm (reuse_pool=True) | ~9 ms |
| speedup | ~105x |

## Test plan
- [x] New `tests/test_warm_pool.py` (11 tests): correctness, pool reuse identity, keying by executor/n_cpu, reuse disabled = no cache, disabling shuts down pools, broken-pool recovery, repeated process `p_apply` vs pandas.
- [x] Full suite green locally (109 passed).
- [ ] CI matrix (pandas 2.0 -> 3.0).