### PR TITLE
feat: add .parallel accessor for p_* methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ res = df.p_quantile(q=[.25, .5, .95], axis=1)
 
 As you can see the `p_quantile` method is **5 times faster**!
 
+### The `.parallel` accessor
+
+Every `p_*` method is also reachable through the `.parallel` accessor, so you can
+drop the prefix and write the call the way you would spell the pandas method:
+
+```python
+df.parallel.quantile(q=[.25, .5, .95], axis=1)   # same as df.p_quantile(...)
+df.parallel.mean()                                # same as df.p_mean()
+df.parallel.apply(my_func, axis=1)                # same as df.p_apply(my_func, axis=1)
+```
+
+The accessor simply forwards `df.parallel.<name>()` to `df.p_<name>()`, so it
+automatically exposes whatever `ParallelPandas.initialize` registered.
+
 ## Usage
 
 Under the hood, **parallel-pandas** works very simply. The Dataframe or Series is split into chunks along the first or second axis. Then these chunks are passed to a pool of processes or threads where the desired method is executed on each part. At the end, the parts are concatenated to get the final result.

--- a/parallel_pandas/core/accessor.py
+++ b/parallel_pandas/core/accessor.py
@@ -1,0 +1,63 @@
+"""A ``.parallel`` accessor for pandas Series/DataFrame.
+
+It lets you call the parallel methods as ``df.parallel.mean()`` instead of
+``df.p_mean()``: every attribute ``x`` is dispatched to the monkey-patched
+``p_x`` method on the underlying object, so the accessor automatically tracks
+whatever ``ParallelPandas.initialize`` registered.
+"""
+import warnings
+
+import pandas as pd
+
+
+class ParallelAccessor:
+    """``.parallel`` namespace dispatching to the ``p_*`` methods.
+
+    Examples
+    --------
+    >>> df.parallel.mean()                 # -> df.p_mean()
+    >>> df.parallel.apply(func, axis=1)     # -> df.p_apply(func, axis=1)
+    >>> df.parallel.chunk_apply(func)       # -> df.chunk_apply(func)
+    """
+
+    # Methods that intentionally keep their own name (no ``p_`` prefix).
+    _ALIASES = {'chunk_apply': 'chunk_apply'}
+
+    def __init__(self, pandas_obj):
+        self._obj = pandas_obj
+
+    def __getattr__(self, name):
+        # Guard against recursion / dunder lookups before ``_obj`` is set.
+        if name.startswith('_'):
+            raise AttributeError(name)
+        target = self._ALIASES.get(name, f'p_{name}')
+        try:
+            return getattr(self._obj, target)
+        except AttributeError:
+            raise AttributeError(
+                f"'parallel' accessor has no method {name!r}. Make sure "
+                f"ParallelPandas.initialize() has been called; the method is "
+                f"exposed as {target!r} on the object once initialized."
+            ) from None
+
+    def __dir__(self):
+        names = [attr[2:] for attr in dir(type(self._obj)) if attr.startswith('p_')]
+        names += list(self._ALIASES)
+        return sorted(set(names))
+
+
+_REGISTERED = False
+
+
+def register_parallel_accessor():
+    """Register the ``.parallel`` accessor on Series and DataFrame (idempotent)."""
+    global _REGISTERED
+    if _REGISTERED:
+        return
+    # Silence pandas' "overriding an existing accessor" warning; registering the
+    # same class under the same name is a no-op we deliberately allow.
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        pd.api.extensions.register_dataframe_accessor('parallel')(ParallelAccessor)
+        pd.api.extensions.register_series_accessor('parallel')(ParallelAccessor)
+    _REGISTERED = True

--- a/parallel_pandas/main.py
+++ b/parallel_pandas/main.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from .core.tools import get_pandas_version
 from .core.progress_imap import TqdmToLogger, set_progress_bar_file, set_reuse_pool
+from .core.accessor import register_parallel_accessor
 
 from .core import series_parallelize_apply
 from .core import series_parallelize_map
@@ -46,6 +47,10 @@ MAJOR, MINOR = get_pandas_version()
 
 PD_VERSION = MAJOR*10 + MINOR
 
+# Register the ``.parallel`` accessor at import time so ``df.parallel`` is always
+# available (it reports a helpful error until ParallelPandas.initialize is run).
+register_parallel_accessor()
+
 
 class ParallelPandas:
     @staticmethod
@@ -54,6 +59,9 @@ class ParallelPandas:
         # Keep worker pools warm across calls (removes the per-call process-spawn
         # overhead). Set reuse_pool=False to restore per-call pool creation.
         set_reuse_pool(reuse_pool)
+
+        # Expose the parallel methods under the ``.parallel`` accessor as well.
+        register_parallel_accessor()
 
         # Route the progress bars: an explicit file-like wins, otherwise a logging.Logger
         # is wrapped so the bars are emitted as log records, otherwise the tqdm default.

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -1,0 +1,48 @@
+"""The .parallel accessor must dispatch to the p_* methods."""
+import pytest
+from pandas.testing import assert_series_equal, assert_frame_equal
+
+
+def test_dataframe_accessor_matches_p_method(df):
+    assert_series_equal(df.parallel.mean().sort_index(),
+                        df.p_mean().sort_index(), check_names=False)
+
+
+def test_dataframe_accessor_matches_pandas(df):
+    assert_series_equal(df.parallel.sum().sort_index(),
+                        df.sum().sort_index(), check_names=False)
+
+
+def test_accessor_apply_passes_args(df):
+    expected = df.apply(lambda row: row.sum(), axis=1)
+    actual = df.parallel.apply(lambda row: row.sum(), axis=1, executor="processes")
+    assert_series_equal(actual, expected)
+
+
+def test_series_accessor(series):
+    expected = series.apply(lambda x: x + 1)
+    actual = series.parallel.apply(lambda x: x + 1, executor="processes")
+    assert_series_equal(actual, expected)
+
+
+def test_accessor_chunk_apply_alias(df):
+    result = df.parallel.chunk_apply(lambda d: d + 1, executor="processes")
+    expected = df.chunk_apply(lambda d: d + 1, executor="processes")
+    assert_frame_equal(result[df.columns], expected[df.columns])
+
+
+def test_unknown_method_raises(df):
+    with pytest.raises(AttributeError, match="no method 'definitely_not_a_method'"):
+        df.parallel.definitely_not_a_method()
+
+
+def test_dir_lists_parallel_methods(df):
+    listing = dir(df.parallel)
+    assert "mean" in listing
+    assert "apply" in listing
+    assert "chunk_apply" in listing
+
+
+def test_accessor_is_same_object_type(df):
+    from parallel_pandas.core.accessor import ParallelAccessor
+    assert isinstance(df.parallel, ParallelAccessor)


### PR DESCRIPTION
## Summary
- Add a pandas `.parallel` accessor on Series and DataFrame so the parallel methods can be called without the `p_` prefix:
  ```python
  df.parallel.mean()               # -> df.p_mean()
  df.parallel.apply(func, axis=1)  # -> df.p_apply(func, axis=1)
  df.parallel.chunk_apply(func)    # -> df.chunk_apply(func)
  ```
- The accessor forwards `.parallel.<name>` to `p_<name>` (with a `chunk_apply` alias and a helpful error for unknown names), so it automatically tracks whatever `ParallelPandas.initialize` registered — no per-method wiring.
- Registered at import time (helpful message before `initialize`) and again inside `initialize` (idempotent).

## Test plan
- [x] New `tests/test_accessor.py` (8 tests): dispatch matches `p_*` and pandas, arg passing, Series accessor, `chunk_apply` alias, unknown-method error, `dir()`, instance type.
- [x] Full local suite green (117 passed).
- [ ] CI matrix (pandas 2.0 -> 3.0).