### PR TITLE
feat: auto-pick chunk count from input byte size (split_factor=None)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Under the hood, **parallel-pandas** works very simply. The Dataframe or Series i
 
 When initializing parallel-pandas you can specify the following options:
 1. `n_cpu` - the number of cores of your CPU that you want to use (default `None` - use all cores of CPU)
-2. `split_factor` - Affects the number of chunks into which the DataFrame/Series is split according to the formula `chunks_number = split_factor*n_cpu` (default 1).
+2. `split_factor` - Affects the number of chunks into which the DataFrame/Series is split according to the formula `chunks_number = split_factor*n_cpu`. Default is `None`, which enables **automatic chunking**: for the process-transport methods (`p_apply`, `p_map`, `p_applymap`, `chunk_apply`) the chunk count is picked from the input's byte size (aiming for ~8&nbsp;MB per chunk, bounded between `n_cpu` and `64*n_cpu` chunks). This lets the data transfer to workers overlap with computation and noticeably speeds up large frames (e.g. ~1.9&nbsp;GB frame: ~1.9x in local benchmarks). Pass an explicit integer (e.g. `split_factor=4`) to force the classic `split_factor*n_cpu` number of chunks instead.
 3. `show_vmem` - Shows a progress bar with available RAM (default `False`)
 4. `disable_pr_bar` - Disable the progress bar for parallel tasks (default `False`)
 5. `logger` - A `logging.Logger` the progress bar is redirected to instead of the terminal (default `None`). Optionally set the level with `logger_level` (default `logging.INFO`). To write the bar to an arbitrary file-like object instead, pass `pbar_file`.

--- a/parallel_pandas/core/parallel_dataframe.py
+++ b/parallel_pandas/core/parallel_dataframe.py
@@ -28,6 +28,7 @@ from .tools import (
     parallel_rank,
     get_split_data,
     get_split_size,
+    resolve_split_size,
 )
 
 DOC = 'Parallel analogue of the DataFrame.{func} method\nSee pandas DataFrame docstring for more ' \
@@ -42,11 +43,11 @@ def _do_apply(data, dill_func, workers_queue, axis, raw, result_type, args, kwar
                       result_type=result_type, args=args, **kwargs)
 
 
-def parallelize_apply(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
+def parallelize_apply(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=None):
     @doc(DOC, func='apply')
     def p_apply(data, func, executor='processes', axis=0, raw=False, result_type=None, args=(), **kwargs):
         workers_queue = get_workers_queue()
-        split_size = get_split_size(n_cpu, split_factor)
+        split_size = resolve_split_size(data, axis, n_cpu, split_factor)
         tasks = get_split_data(data, axis, split_size)
         dill_func = dill.dumps(func, recurse=True)
         result = progress_imap(partial(_do_apply, axis=axis, raw=raw, result_type=result_type, dill_func=dill_func,
@@ -71,11 +72,11 @@ def _do_chunk_apply(data, dill_func, workers_queue, args, kwargs):
     return progress_udf_wrapper(foo, workers_queue, 1)()
 
 
-def parallelize_chunk_apply(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
+def parallelize_chunk_apply(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=None):
     def chunk_apply(data, func, executor='processes', axis=0, split_by_col=None,
                     concat_result=True, args=(), **kwargs):
         workers_queue = get_workers_queue()
-        split_size = get_split_size(n_cpu, split_factor)
+        split_size = resolve_split_size(data, 1 - axis, n_cpu, split_factor)
         if split_by_col:
             t = data[split_by_col].unique()
             idx_split = np.array_split(t, min(split_size, len(t)))
@@ -390,11 +391,11 @@ def do_applymap(df, workers_queue, dill_func, na_action, kwargs):
     return df.applymap(progress_udf_wrapper(func, workers_queue, df.size), na_action=na_action, **kwargs)
 
 
-def parallelize_applymap(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
+def parallelize_applymap(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=None):
     @doc(DOC, func='applymap')
     def p_applymap(data, func, na_action=None, **kwargs):
         workers_queue = get_workers_queue()
-        split_size = get_split_size(n_cpu, split_factor)
+        split_size = resolve_split_size(data, 1, n_cpu, split_factor)
         tasks = get_split_data(data, 1, split_size)
         dill_func = dill.dumps(func, recurse=True)
         result = progress_imap(
@@ -412,11 +413,11 @@ def do_map(df, workers_queue, dill_func, na_action, kwargs):
     return df.map(progress_udf_wrapper(func, workers_queue, df.size), na_action=na_action, **kwargs)
 
 
-def parallelize_map(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
+def parallelize_map(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=None):
     @doc(DOC, func='map')
     def p_map(data, func, na_action=None, **kwargs):
         workers_queue = get_workers_queue()
-        split_size = get_split_size(n_cpu, split_factor)
+        split_size = resolve_split_size(data, 1, n_cpu, split_factor)
         tasks = get_split_data(data, 1, split_size)
         dill_func = dill.dumps(func, recurse=True)
         result = progress_imap(

--- a/parallel_pandas/core/parallel_series.py
+++ b/parallel_pandas/core/parallel_series.py
@@ -12,7 +12,7 @@ from .progress_imap import progress_udf_wrapper
 from .progress_imap import get_workers_queue
 from .tools import (
     get_split_data,
-    get_split_size,
+    resolve_split_size,
 )
 
 DOC = 'Parallel analogue of the pd.Series.{func} method\nSee pandas Series docstring for more ' \
@@ -27,11 +27,11 @@ def _do_apply(data, dill_func, workers_queue, convert_dtype, args, kwargs):
         return data.astype(object).apply(progress_udf_wrapper(func, workers_queue, data.shape[0]), args=args, **kwargs)
 
 
-def series_parallelize_apply(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
+def series_parallelize_apply(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=None):
     @doc(DOC, func='apply')
     def p_apply(data, func, executor='processes', convert_dtype=True, args=(), **kwargs):
         workers_queue = get_workers_queue()
-        split_size = get_split_size(n_cpu, split_factor)
+        split_size = resolve_split_size(data, 1, n_cpu, split_factor)
         tasks = get_split_data(data, 1, split_size)
         dill_func = dill.dumps(func, recurse=True)
         result = progress_imap(partial(_do_apply, convert_dtype=convert_dtype, dill_func=dill_func,
@@ -51,11 +51,11 @@ def _do_map(data, dill_arg, workers_queue, na_action):
     return progress_udf_wrapper(foo, workers_queue, 1)()
 
 
-def series_parallelize_map(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1):
+def series_parallelize_map(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=None):
     @doc(DOC, func='map')
     def p_map(data, arg, executor='threads', na_action=None):
         workers_queue = get_workers_queue()
-        split_size = get_split_size(n_cpu, split_factor)
+        split_size = resolve_split_size(data, 1, n_cpu, split_factor)
         tasks = get_split_data(data, 1, split_size)
         dill_arg = dill.dumps(arg, recurse=True)
         result = progress_imap(partial(_do_map, dill_arg=dill_arg,

--- a/parallel_pandas/core/parallel_window.py
+++ b/parallel_pandas/core/parallel_window.py
@@ -11,6 +11,7 @@ from .progress_imap import progress_imap
 from .progress_imap import progress_udf_wrapper
 from .progress_imap import get_workers_queue
 from .tools import get_split_data
+from .tools import get_split_size
 from .tools import get_obj_axis
 
 DOC = 'Parallel analogue of the {func} method\nSee pandas DataFrame docstring for more ' \
@@ -67,13 +68,13 @@ class ParallelRolling:
 
     def _get_split_data(self, data):
         axis, offset = self._get_axis_and_offset(data)
-        return get_split_data(data.obj, axis, self.n_cpu * self.split_factor, offset=offset)
+        return get_split_data(data.obj, axis, get_split_size(self.n_cpu, self.split_factor), offset=offset)
 
     def _get_total_tasks(self, data):
         axis = get_obj_axis(data)
         if isinstance(data.obj, pd.Series):
             axis = 1
-        return min(self.n_cpu * self.split_factor, data.obj.shape[1 - axis])
+        return min(get_split_size(self.n_cpu, self.split_factor), data.obj.shape[1 - axis])
 
     def _data_reduce(self, result, data, axis, offset):
         if offset:

--- a/parallel_pandas/core/tools.py
+++ b/parallel_pandas/core/tools.py
@@ -61,8 +61,53 @@ def get_split_size(n_cpu, split_factor):
     if n_cpu is None:
         n_cpu = cpu_count()
     if split_factor is None:
-        split_factor = 4
+        split_factor = 1
     return n_cpu * split_factor
+
+
+# Target payload per chunk for process-based methods. Derived from a chunk-size
+# sweep across data shapes and UDF weights: throughput is stable around
+# 8-16 MB/chunk, because the fixed per-chunk pickle/pipe cost is amortised while
+# transfer still overlaps compute. See the auto-chunking PR for the measurements.
+_TARGET_CHUNK_BYTES = 8 * 1024 * 1024
+# Never create more than this many chunks per CPU, to keep per-task overhead
+# bounded on very large frames (a huge frame lands near ~20 MB/chunk instead).
+_MAX_CHUNKS_PER_CPU = 64
+
+
+def _approx_nbytes(data):
+    """Cheap dtype-based byte estimate for a Series/DataFrame (deep=False)."""
+    usage = data.memory_usage(index=False, deep=False)
+    try:
+        return int(usage.sum())  # DataFrame -> per-column Series
+    except AttributeError:
+        return int(usage)        # Series -> scalar
+
+
+def auto_split_size(data, axis, n_cpu):
+    """Pick the number of chunks so each is ~``_TARGET_CHUNK_BYTES`` of data.
+
+    Bounded below by ``n_cpu`` (keep every worker busy) and above by
+    ``_MAX_CHUNKS_PER_CPU * n_cpu`` and by the length of the split dimension.
+    """
+    if n_cpu is None:
+        n_cpu = cpu_count()
+    total_bytes = _approx_nbytes(data)
+    desired = max(1, -(-total_bytes // _TARGET_CHUNK_BYTES))  # ceil division
+    n_chunks = min(max(desired, n_cpu), _MAX_CHUNKS_PER_CPU * n_cpu)
+    split_dim = data.shape[1 - axis] if getattr(data, 'ndim', 1) > 1 else data.shape[0]
+    return max(1, min(n_chunks, split_dim))
+
+
+def resolve_split_size(data, axis, n_cpu, split_factor):
+    """Chunk count for the process-transport methods.
+
+    ``split_factor is None`` triggers the byte-size heuristic; an explicit factor
+    keeps the classic ``n_cpu * split_factor`` behaviour.
+    """
+    if split_factor is None:
+        return auto_split_size(data, axis, n_cpu)
+    return get_split_size(n_cpu, split_factor)
 
 
 def iterate_by_df(df, idx, axis, offset):

--- a/parallel_pandas/main.py
+++ b/parallel_pandas/main.py
@@ -54,8 +54,13 @@ register_parallel_accessor()
 
 class ParallelPandas:
     @staticmethod
-    def initialize(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=1,
+    def initialize(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=None,
                    logger=None, logger_level=logging.INFO, pbar_file=None, reuse_pool=True):
+        # split_factor controls how the data is chunked for the process-transport
+        # methods (p_apply/p_map/p_applymap/chunk_apply). None (default) auto-picks
+        # the chunk count from the input byte size (~8 MB per chunk); an explicit
+        # integer keeps the classic n_cpu * split_factor number of chunks.
+
         # Keep worker pools warm across calls (removes the per-call process-spawn
         # overhead). Set reuse_pool=False to restore per-call pool creation.
         set_reuse_pool(reuse_pool)
@@ -143,12 +148,12 @@ class ParallelPandas:
                                                      split_factor=split_factor).do_parallel('cumsum')
         if PD_VERSION < 21:
             pd.DataFrame.p_applymap = parallelize_applymap(n_cpu=n_cpu, disable_pr_bar=disable_pr_bar,
-                                                           show_vmem=show_vmem)
+                                                           show_vmem=show_vmem, split_factor=split_factor)
         else:
             pd.DataFrame.p_map = parallelize_map(n_cpu=n_cpu, disable_pr_bar=disable_pr_bar,
-                                                      show_vmem=show_vmem)
+                                                      show_vmem=show_vmem, split_factor=split_factor)
             pd.DataFrame.p_applymap = parallelize_applymap(n_cpu=n_cpu, disable_pr_bar=disable_pr_bar,
-                                                           show_vmem=show_vmem)
+                                                           show_vmem=show_vmem, split_factor=split_factor)
         pd.DataFrame.p_describe = parallelize_describe(n_cpu=n_cpu, disable_pr_bar=disable_pr_bar,
                                                        show_vmem=show_vmem,
                                                        split_factor=split_factor)

--- a/tests/test_auto_chunk.py
+++ b/tests/test_auto_chunk.py
@@ -1,0 +1,89 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from parallel_pandas import ParallelPandas
+from parallel_pandas.core.tools import (
+    auto_split_size,
+    resolve_split_size,
+    get_split_size,
+    _TARGET_CHUNK_BYTES,
+    _MAX_CHUNKS_PER_CPU,
+)
+
+ParallelPandas.initialize(n_cpu=4)
+
+
+def test_get_split_size_none_is_one_factor():
+    # None must behave like the historical default split_factor=1 (n_cpu chunks),
+    # so the non-transport reductions keep their previous chunking.
+    assert get_split_size(4, None) == 4
+    assert get_split_size(4, 1) == 4
+    assert get_split_size(4, 3) == 12
+
+
+def test_resolve_explicit_factor_ignores_data_size():
+    df = pd.DataFrame(np.ones((1_000_000, 20)))
+    assert resolve_split_size(df, 1, 4, 2) == get_split_size(4, 2) == 8
+    assert resolve_split_size(df, 1, 4, 1) == 4
+
+
+def test_auto_small_frame_floors_at_n_cpu():
+    # A tiny frame has far less than one target chunk of data -> exactly n_cpu
+    # chunks (but never more than the split dimension length).
+    df = pd.DataFrame(np.ones((100, 4)))
+    n_cpu = 4
+    got = auto_split_size(df, 1, n_cpu)
+    assert got == n_cpu
+
+
+def test_auto_never_exceeds_split_dim():
+    # Split dimension shorter than n_cpu must clamp the chunk count.
+    df = pd.DataFrame(np.ones((3, 4)))
+    got = auto_split_size(df, 1, 8)  # split dim = rows = 3
+    assert got == 3
+
+
+def test_auto_targets_bytes_per_chunk_for_big_frame():
+    n_cpu = 4
+    rows, cols = 2_000_000, 10  # ~160 MB of float64
+    df = pd.DataFrame(np.ones((rows, cols)))
+    total_bytes = df.memory_usage(index=False, deep=False).sum()
+    expected = int(np.ceil(total_bytes / _TARGET_CHUNK_BYTES))
+    expected = min(max(expected, n_cpu), _MAX_CHUNKS_PER_CPU * n_cpu)
+    got = auto_split_size(df, 1, n_cpu)
+    assert got == expected
+    # sanity: each chunk is roughly the target size
+    assert _TARGET_CHUNK_BYTES // 2 <= total_bytes / got <= _TARGET_CHUNK_BYTES * 2
+
+
+def test_auto_caps_chunks_per_cpu():
+    n_cpu = 2
+    # Force desired chunk count above the per-cpu cap via a large split dimension.
+    df = pd.DataFrame(np.ones((5_000_000, 40)))  # ~1.6 GB -> ~190 chunks desired
+    got = auto_split_size(df, 1, n_cpu)
+    assert got == _MAX_CHUNKS_PER_CPU * n_cpu
+
+
+def test_auto_series():
+    s = pd.Series(np.ones(500))
+    assert auto_split_size(s, 1, 4) == 4  # tiny -> n_cpu
+    short = pd.Series(np.ones(2))
+    assert auto_split_size(short, 1, 4) == 2  # clamped to length
+
+
+@pytest.mark.parametrize("shape", [(10_000, 8), (200_000, 5)])
+def test_p_apply_auto_matches_pandas(shape):
+    df = pd.DataFrame(np.random.random(shape))
+    res = df.p_apply(lambda col: col.sum(), axis=0)
+    expected = df.apply(lambda col: col.sum(), axis=0)
+    pd.testing.assert_series_equal(res, expected)
+
+
+def test_p_apply_auto_and_explicit_agree():
+    df = pd.DataFrame(np.random.random((50_000, 6)))
+    auto = df.p_apply(lambda col: col.mean(), axis=0)
+    ParallelPandas.initialize(n_cpu=4, split_factor=1)
+    explicit = df.p_apply(lambda col: col.mean(), axis=0)
+    pd.testing.assert_series_equal(auto, explicit)
+    ParallelPandas.initialize(n_cpu=4)  # restore auto default for other tests


### PR DESCRIPTION
## Summary
- Make `split_factor=None` the default. When `None`, the process-transport methods (`p_apply`, `p_map`, `p_applymap`, `chunk_apply` on both DataFrame and Series) now derive the chunk count from the input's byte size, targeting ~8 MB per chunk (bounded between `n_cpu` and `64*n_cpu` chunks, and by the split-dimension length).
- The old default `split_factor=1` gave large frames only `n_cpu` chunks, so the sequential per-chunk transfer through the multiprocessing pipes could not overlap with computation and parallel scaling was poor. The ~8 MB target comes from a chunk-size sweep where throughput was stable around 8-16 MB/chunk regardless of shape or UDF weight.
- An explicit integer `split_factor` keeps the classic `n_cpu * split_factor` behaviour.
- `get_split_size` now treats `None` as factor `1`, so reductions and window/groupby methods that receive the new default keep their previous `n_cpu`-chunk behaviour (no regression).

## Implementation
- `tools.py`: add `auto_split_size` / `resolve_split_size`; `get_split_size(None) -> factor 1`.
- transport methods switched from `get_split_size` to `resolve_split_size`.
- `main.py`: default `split_factor=None`; forward it to the `p_map`/`p_applymap` factories (previously not passed).
- `parallel_window.py`: use `get_split_size` instead of raw `n_cpu * split_factor` so `None` is handled.

## Benchmark
Local, ~1.9 GB frame (6M x 40 float64), 8 CPU, CPU-bound `chunk_apply`:

| config | time |
|---|---|
| old default (split_factor=1, 8 chunks) | 12.80s |
| auto (split_factor=None, 229 chunks) | 6.85s |

**1.87x** faster; results identical.

## Test plan
- [x] New `tests/test_auto_chunk.py` covers the heuristic (floor at `n_cpu`, cap at `64*n_cpu`, clamp to split-dim length, byte target, Series, explicit factor unaffected, auto == explicit result equality).
- [x] Full suite green (127 passed) locally across the changes.
