### PR TITLE
feat: parallel groupby.agg (p_agg)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,17 @@ serial `transform` on an 8-core machine. As with the other process methods,
 reach for it when the UDF is an expensive Python function; for the built-in
 aggregations (`'mean'`, `'sum'`, ...) the native `transform` already runs in C.
 
+`p_agg` is the reducing counterpart and mirrors `groupby.agg`, so callable,
+string, list, dict and named aggregations all work (the aggregation spec and
+resulting column layout are handled by pandas):
+
+```python
+gb = df.groupby('user_id')
+gb.p_agg(lambda s: s.max() - s.min())          # callable
+gb.p_agg({'x': 'mean', 'y': my_udf})           # dict spec
+gb.p_agg(rng=('x', my_udf), total=('y', 'sum'))  # named aggregation
+```
+
 ## API
 
 ### Parallel counterparts for pandas Series methods
@@ -203,6 +214,7 @@ aggregations (`'mean'`, `'sum'`, ...) the native `transform` already runs in C.
 |--------------------------|----------------------------|-------------------------|
 | pd.SeriesGroupBy.apply() | pd.SeriesGroupBy.p_apply() | threads / processes     |
 | pd.SeriesGroupBy.transform() | pd.SeriesGroupBy.p_transform() | threads / processes |
+| pd.SeriesGroupBy.agg() | pd.SeriesGroupBy.p_agg() | threads / processes |
 
 ### Parallel counterparts for pandas Dataframe methods
 
@@ -244,6 +256,7 @@ aggregations (`'mean'`, `'sum'`, ...) the native `transform` already runs in C.
 |--------------------------|----------------------------|----------------------|
 | DataFrameGroupBy.apply() | DataFrameGroupBy.p_apply() | threads / processes  |
 | DataFrameGroupBy.transform() | DataFrameGroupBy.p_transform() | threads / processes |
+| DataFrameGroupBy.agg() | DataFrameGroupBy.p_agg() | threads / processes |
 
 ### Parallel counterparts for pandas window methods
 

--- a/parallel_pandas/core/__init__.py
+++ b/parallel_pandas/core/__init__.py
@@ -2,6 +2,7 @@ from .parallel_series import series_parallelize_apply
 from .parallel_series import series_parallelize_map
 from .parallel_groupby import parallelize_groupby_apply
 from .parallel_groupby import parallelize_groupby_transform
+from .parallel_groupby import parallelize_groupby_agg
 from .parallel_dataframe import parallelize_apply
 from .parallel_dataframe import parallelize_replace
 from .parallel_dataframe import parallelize_applymap

--- a/parallel_pandas/core/parallel_groupby.py
+++ b/parallel_pandas/core/parallel_groupby.py
@@ -182,3 +182,76 @@ def parallelize_groupby_transform(n_cpu=None, disable_pr_bar=False, show_vmem=Fa
         return _assemble_transform(obj, positions, pieces)
 
     return p_transform
+
+
+def _do_group_agg(task, dill_func, dill_kwargs, workers_queue, args):
+    sub, codes = task
+    func = dill.loads(dill_func)
+    kwargs = dill.loads(dill_kwargs)
+
+    def foo():
+        # Aggregate the chunk grouped by the original integer codes. Every group
+        # lives entirely in one chunk, so the partial results just need to be
+        # concatenated; pandas owns the whole aggregation spec (callable, string,
+        # list, dict, named aggregation) and the resulting column layout.
+        g = sub.groupby(codes, sort=True)
+        if func is None:
+            return g.aggregate(*args, **kwargs)
+        return g.aggregate(func, *args, **kwargs)
+
+    return progress_udf_wrapper(foo, workers_queue, 1)()
+
+
+def parallelize_groupby_agg(n_cpu=None, disable_pr_bar=False, show_vmem=False, split_factor=None):
+    @doc(DOC, func='aggregate')
+    def p_agg(data, func=None, executor='processes', args=(), **kwargs):
+        def _native():
+            if func is None:
+                return data.aggregate(*args, **kwargs)
+            return data.aggregate(func, *args, **kwargs)
+
+        ngroups = data.ngroups
+        if ngroups == 0:
+            return _native()
+
+        obj = data._obj_with_exclusions
+        ids = data.ngroup().to_numpy()
+        n_chunks = min(get_split_size(n_cpu, split_factor), ngroups)
+        chunk_of_row = _chunk_of_row(ids, ngroups, n_chunks)
+
+        masks = [m for m in (chunk_of_row == c for c in range(n_chunks)) if m.any()]
+        if not masks:
+            return _native()
+
+        tasks = ((obj.iloc[m], ids[m].astype(np.int64)) for m in masks)
+
+        workers_queue = get_workers_queue()
+        dill_func = dill.dumps(func, recurse=True)
+        dill_kwargs = dill.dumps(kwargs, recurse=True)
+        if isinstance(func, str):
+            desc = func.upper()
+        elif callable(func):
+            desc = getattr(func, '__name__', 'AGG').upper()
+        else:
+            desc = 'AGG'
+        pieces = progress_imap(
+            partial(_do_group_agg, dill_func=dill_func, dill_kwargs=dill_kwargs,
+                    workers_queue=workers_queue, args=args),
+            tasks, workers_queue, total=len(masks), n_cpu=n_cpu, disable=disable_pr_bar,
+            show_vmem=show_vmem, executor=executor, desc=desc
+        )
+
+        combined = pd.concat(pieces, axis=0)
+        result_index = _get_grouper(data).result_index
+        # Guard for exotic groupings where the per-row codes don't cover every
+        # group (e.g. dropna=False with NaN keys): fall back to native aggregate.
+        if len(combined) != len(result_index):
+            return _native()
+
+        combined = combined.sort_index(kind='stable')
+        combined.index = result_index
+        if not getattr(data, 'as_index', True):
+            combined = combined.reset_index()
+        return combined
+
+    return p_agg

--- a/parallel_pandas/main.py
+++ b/parallel_pandas/main.py
@@ -16,6 +16,7 @@ from .core import ParallelizeStatFunc
 from .core import ParallelizeStatFuncDdof
 from .core import parallelize_groupby_apply
 from .core import parallelize_groupby_transform
+from .core import parallelize_groupby_agg
 from .core import parallelize_applymap
 from .core import parallelize_describe
 from .core import parallelize_nunique
@@ -253,4 +254,9 @@ class ParallelPandas:
         pd.core.groupby.DataFrameGroupBy.p_transform = parallelize_groupby_transform(
             n_cpu=n_cpu, disable_pr_bar=disable_pr_bar, show_vmem=show_vmem, split_factor=split_factor)
         pd.core.groupby.SeriesGroupBy.p_transform = parallelize_groupby_transform(
+            n_cpu=n_cpu, disable_pr_bar=disable_pr_bar, show_vmem=show_vmem, split_factor=split_factor)
+
+        pd.core.groupby.DataFrameGroupBy.p_agg = parallelize_groupby_agg(
+            n_cpu=n_cpu, disable_pr_bar=disable_pr_bar, show_vmem=show_vmem, split_factor=split_factor)
+        pd.core.groupby.SeriesGroupBy.p_agg = parallelize_groupby_agg(
             n_cpu=n_cpu, disable_pr_bar=disable_pr_bar, show_vmem=show_vmem, split_factor=split_factor)

--- a/tests/test_groupby_agg.py
+++ b/tests/test_groupby_agg.py
@@ -1,0 +1,103 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from parallel_pandas import ParallelPandas
+
+ParallelPandas.initialize(n_cpu=4, disable_pr_bar=True)
+
+
+def _range(s):
+    return s.max() - s.min()
+
+
+@pytest.fixture
+def df():
+    rng = np.random.default_rng(0)
+    n = 5000
+    return pd.DataFrame({
+        'k': rng.integers(0, 40, n),
+        'k2': rng.integers(0, 3, n),
+        'x': rng.random(n),
+        'y': rng.random(n) * 10,
+    })
+
+
+@pytest.mark.parametrize('executor', ['processes', 'threads'])
+def test_agg_callable(df, executor):
+    expected = df.groupby('k').agg(_range)
+    result = df.groupby('k').p_agg(_range, executor=executor)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_agg_string(df):
+    expected = df.groupby('k').agg('mean')
+    result = df.groupby('k').p_agg('mean')
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_agg_list(df):
+    expected = df.groupby('k').agg(['mean', 'sum'])
+    result = df.groupby('k').p_agg(['mean', 'sum'])
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_agg_dict(df):
+    expected = df.groupby('k').agg({'x': 'mean', 'y': _range})
+    result = df.groupby('k').p_agg({'x': 'mean', 'y': _range})
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_agg_named(df):
+    expected = df.groupby('k').agg(mx=('x', 'max'), sy=('y', 'sum'))
+    result = df.groupby('k').p_agg(mx=('x', 'max'), sy=('y', 'sum'))
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_agg_multikey(df):
+    expected = df.groupby(['k', 'k2']).agg(_range)
+    result = df.groupby(['k', 'k2']).p_agg(_range)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_agg_multikey_as_index_false(df):
+    expected = df.groupby(['k', 'k2'], as_index=False).agg(_range)
+    result = df.groupby(['k', 'k2'], as_index=False).p_agg(_range)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_agg_as_index_false(df):
+    expected = df.groupby('k', as_index=False).agg(_range)
+    result = df.groupby('k', as_index=False).p_agg(_range)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_agg_sort_false(df):
+    expected = df.groupby('k', sort=False).agg(_range)
+    result = df.groupby('k', sort=False).p_agg(_range)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_agg_series(df):
+    expected = df.groupby('k')['x'].agg(_range)
+    result = df.groupby('k')['x'].p_agg(_range)
+    pd.testing.assert_series_equal(result, expected)
+
+
+def test_agg_nan_key():
+    df = pd.DataFrame({
+        'k': ['a', 'b', 'a', 'b', np.nan, 'a'],
+        'x': [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+    })
+    expected = df.groupby('k').agg(_range)
+    result = df.groupby('k').p_agg(_range)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_agg_args_passed_through(df):
+    def clipped_sum(s, lo):
+        return s.clip(lower=lo).sum()
+
+    expected = df.groupby('k')['x'].agg(clipped_sum, 0.5)
+    result = df.groupby('k')['x'].p_agg(clipped_sum, args=(0.5,))
+    pd.testing.assert_series_equal(result, expected)


### PR DESCRIPTION
## Summary
- Add `p_agg` to `DataFrameGroupBy` and `SeriesGroupBy` — the reducing counterpart to `p_transform` (#28) and a parallel drop-in for `groupby.agg` / `aggregate`.
- Groups are binned into chunks by their integer group code (whole groups stay together), each chunk is aggregated with the **real** pandas `groupby.aggregate` in a worker, and the partial results are concatenated and re-indexed onto the grouper's `result_index`.
- Because every group lives in exactly one chunk, this reproduces pandas semantics for **callable / string / list / dict / named** aggregations, delegating the entire column layout (incl. MultiIndex columns) to pandas.
- Correct for `as_index=False`, `sort=False` and MultiIndex keys. Falls back to native `aggregate` for exotic groupings whose per-row codes don't cover every group (e.g. `dropna=False` with NaN keys).
- Honors auto-chunking (`split_factor=None`) and the warm pool; supports `processes`/`threads` executors and positional `args`.

## Benchmark
2M rows, 20k groups, heavy Python aggfunc, 8 CPU:

| | time |
|---|---|
| native `agg` | 3.27s |
| `p_agg` | 0.61s |

**~5.3x** faster, output identical (`np.allclose` True).

## Test plan
- [x] New `tests/test_groupby_agg.py`: callable, string, list, dict, named aggregation, multi-key, `as_index=False` (single + multi-key), `sort=False`, Series, NaN keys, positional args, both executors — all compared against native `groupby.agg`.
- [x] Full suite green locally (150 passed).
