### PR TITLE
release: 0.8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: publish
+
+# Build the sdist/wheel and publish to PyPI when a version tag is pushed
+# (e.g. `git tag v0.8 && git push origin v0.8`). Publishing uses PyPI Trusted
+# Publishing (OIDC), so no API token secret is stored in the repo - configure a
+# trusted publisher for this workflow on PyPI once:
+# https://docs.pypi.org/trusted-publishers/
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Check metadata
+        run: |
+          python -m pip install twine
+          twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is loosely
+based on [Keep a Changelog](https://keepachangelog.com/), and the project
+follows a simple `MAJOR.MINOR` versioning scheme.
+
+## 0.8
+
+### Added
+- **Parallel `groupby.transform`** — `DataFrameGroupBy.p_transform` /
+  `SeriesGroupBy.p_transform`. Groups are chunked by their integer code and the
+  real pandas `transform` runs on each chunk, reproducing pandas semantics
+  exactly (column fast-path, broadcasting, string ops, NaN keys). ~5x faster
+  than serial `transform` for heavy Python UDFs.
+- **Parallel `groupby.agg`** — `DataFrameGroupBy.p_agg` / `SeriesGroupBy.p_agg`.
+  Supports callable / string / list / dict / named aggregations and
+  `as_index=False`, `sort=False`, MultiIndex keys. ~5x faster than serial `agg`
+  for heavy aggfuncs.
+- **Parallel `.str` and `.dt` accessors** on the Series `.parallel` namespace:
+  `s.parallel.str.<op>()` and `s.parallel.dt.<op>()` (methods return a callable,
+  accessor properties like `dt.year` are evaluated eagerly). Best for CPU-heavy
+  per-element ops such as regex `extract`/`replace` and `strftime`.
+- **`.parallel` accessor** — every `p_*` method is reachable as
+  `df.parallel.<name>()` in addition to `df.p_<name>()`.
+- **Automatic chunk sizing** — `split_factor` now defaults to `None`, which
+  auto-picks the number of chunks from the input byte size (~8 MB per chunk) for
+  the process-transport methods (`p_apply`, `p_map`, `p_applymap`,
+  `chunk_apply`). Large frames parallelize noticeably better (~1.9x on a ~1.9 GB
+  frame). Pass an explicit integer to keep the classic `split_factor * n_cpu`
+  behaviour.
+- **Warm worker pools** — `reuse_pool=True` (default) keeps the process/thread
+  pool alive across calls, removing the per-call spawn overhead. Set
+  `reuse_pool=False` to restore per-call pools.
+- **Parallel `DataFrame.p_pivot_table`** (closes #3).
+- **Progress-bar redirection to a logger** via `ParallelPandas.initialize(logger=...)`
+  (and `pbar_file=...` for an arbitrary file-like), closes #15.
+
+### Changed
+- Support for **pandas 3.0**; the supported floor is now **pandas 2.0**, both
+  covered by the CI version matrix.
+- Internal refactors of the stat/window `do_parallel` dispatchers (no API
+  change).
+
+### Fixed
+- User functions that reference module-level globals (e.g. `numpy`) now work
+  under the `spawn` start method (closes #13).
+- Various parallel window bugs, backed by a new test suite and GitHub Actions CI
+  across a Python/pandas version matrix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "parallel-pandas"
-version = "0.7"
+version = "0.8"
 description = "Parallel processing on pandas with progress bars"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
Cuts the **0.8** release.

- Bump `version` 0.7 -> 0.8 in `pyproject.toml`.
- Add `CHANGELOG.md` documenting the 0.8 features: parallel `groupby.transform`/`agg`, parallel `.str`/`.dt` accessors, the `.parallel` accessor, automatic chunk sizing (`split_factor=None`), warm worker pools, `p_pivot_table`, progress-bar-to-logger redirection, and pandas 2.0-3.0 support.
- Add `.github/workflows/publish.yml`: on a `v*` tag it builds the sdist/wheel, runs `twine check`, and publishes to PyPI via **Trusted Publishing (OIDC)** — no API token is stored in the repo.

## Verified
- `python -m build` produces `parallel_pandas-0.8.tar.gz` + wheel; `twine check` PASSED; the wheel includes all modules (incl. the new `parallel_str_dt.py`).
- Full test suite green locally (177 passed).

## Release steps after merge
1. One-time on PyPI: add a Trusted Publisher for this repo + `publish.yml` (and, if desired, a `pypi` environment). https://docs.pypi.org/trusted-publishers/
2. Tag and push: `git tag v0.8 && git push origin v0.8` — this triggers the publish workflow.

_Alternative without Trusted Publishing:_ set a `PYPI_API_TOKEN` secret and switch the publish step to token auth, or run `flit publish` / `twine upload dist/*` locally.
